### PR TITLE
Update schema: public address, no schema version

### DIFF
--- a/featureflags.schema.json
+++ b/featureflags.schema.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://onebranch.visualstudio.com/Build/_git/Powershell-FeatureFlags?path=%2Ffeatureflags.schema.json",
+    "$id": "https://raw.githubusercontent.com/microsoft/PowerShell-FeatureFlags/main/featureflags.schema.json",
     "title": "Feature Flags Schema",
     "description": "Describes a schema for the Powershell-FeatureFlags configuration file.",
     "type": "object",


### PR DESCRIPTION
* change the address to be the public one rather than a private Azure DevOps repo;
* remove the schema version, because the JSON Schema library I'm targeting for the next upgrade fails to parse the schema if I specify the version.