### PR TITLE
Add CmdletBinding attribute to all cmdlets

### DIFF
--- a/FeatureFlags.psm1
+++ b/FeatureFlags.psm1
@@ -10,7 +10,11 @@ Path to the JSON file containing the configuration.
 The output of ConvertFrom-Json (PSCustomObject) if the file contains a valid JSON object
 that matches the feature flags JSON schema, $null otherwise.
 #>
-function Get-FeatureFlagConfigFromFile([string]$jsonConfigPath) {
+function Get-FeatureFlagConfigFromFile {
+    [CmdletBinding()]
+    param(
+       [string]$jsonConfigPath
+    )
     $configJson = Get-Content $jsonConfigPath | Out-String
     if (-not (Confirm-FeatureFlagConfig $configJson)) {
         return $null
@@ -131,6 +135,7 @@ $false in case of such invalid configuration rather than throwing exceptions tha
 to be handled.
 #>
 function Confirm-FeatureFlagConfig {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
         [AllowNull()]
@@ -177,7 +182,8 @@ function Confirm-FeatureFlagConfig {
 # Unfortunately it's impossible to express this concept with the current
 # JSON schema standard.
 function Confirm-StagesPointers {
-    param(   
+    [CmdletBinding()]   
+    param(
         [string] $serializedJson
     )
 
@@ -264,6 +270,7 @@ function Test-FeatureFlag {
 
 function Test-FeatureConditions
 {
+    [CmdletBinding()]
     param(
         [PSCustomObject] $conditions,
         [string] $predicate,
@@ -320,6 +327,7 @@ Array of the supported features by name.
 #>
 function Get-SupportedFeatures
 {
+    [CmdletBinding()]
     param(
         [PSCustomObject] $config
     )
@@ -348,6 +356,7 @@ Returns the environment variables collection associated with a specific feature
 #>
 function Get-FeatureEnvironmentVariables
 {
+    [CmdletBinding()]
     param(
         [PSCustomObject] $Config,
         [string] $FeatureName
@@ -372,6 +381,7 @@ Returns an array of the evaluated feature flags given the specified predicate.
 #>
 function Get-EvaluatedFeatureFlags
 {
+    [CmdletBinding()]
     param(
         [string] $predicate,
         [PSCustomObject] $config
@@ -411,6 +421,7 @@ Outputs multiple file formats expressing the evaluated feature flags
 #>
 function Out-EvaluatedFeaturesFiles
 {
+    [CmdletBinding()]
     param(
         [PSCustomObject] $Config,
         [PSCustomObject] $EvaluatedFeatures,

--- a/test/FeatureFlags.Tests.ps1
+++ b/test/FeatureFlags.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Confirm-FeatureFlagConfig' {
         }
     }
 
-    Context 'Error output' {
+    Context 'Error output of Confirm-FeatureFlagConfig' {
         It 'Outputs correct error messages in case of failure' {
             # Write-Error will add errors to the $error variable and output them to standard error.
             # When run with -EA 0 (ErrorAction SilentlyContinue), the errors will be added to $error
@@ -56,6 +56,15 @@ Describe 'Confirm-FeatureFlagConfig' {
 
             Confirm-FeatureFlagConfig -EA 0 '{"stages": {"foo": []}}' | Should -Be $false
             $error[0] | Should -BeLike "*Validation failed*"
+        }
+    }
+
+    Context 'Error output of Get-FeatureFlagConfigFromFile' {
+        It 'Outputs correct error messages in case of failure' {
+            # Write-Error will add errors to the $error variable and output them to standard error.
+            # When run with -EA 0 (ErrorAction SilentlyContinue), the errors will be added to $error
+            # but not printed to stderr, which is desirable to not litter the unit tests output.
+            Get-FeatureFlagConfigFromFile -jsonConfigPath "this/file/does/not/exist" -EA 0 | Should -Be $null
         }
     }
 


### PR DESCRIPTION
This will allow, among other things, propagation of the ErrorAction parameter, and correctly inhibit output when needed.

This behavior is tested in a new test for Get-FeatureFlagConfigFromFile.

Fixes Lack of CmdletBinding prevents ErrorAction from propagating #53