### PR TITLE
fix: remove () from type name in tests

### DIFF
--- a/test/FeatureFlags.Tests.ps1
+++ b/test/FeatureFlags.Tests.ps1
@@ -604,9 +604,9 @@ Describe 'Get-EvaluatedFeatureFlags' -Tag Features {
 Describe 'Out-EvaluatedFeaturesFiles' -Tag Features {
     Context 'Verify output file content' {
         BeforeAll {
-            $global:featuresJsonContent = New-Object 'System.Collections.ArrayList()'
-            $global:featuresIniContent = New-Object 'System.Collections.ArrayList()'
-            $global:featuresEnvConfigContent = New-Object 'System.Collections.ArrayList()'
+            $global:featuresJsonContent = New-Object 'System.Collections.ArrayList'
+            $global:featuresIniContent = New-Object 'System.Collections.ArrayList'
+            $global:featuresEnvConfigContent = New-Object 'System.Collections.ArrayList'
 
             $serializedConfig = Get-Content -Raw "$PSScriptRoot\multiple-stages-features.json"
             Confirm-FeatureFlagConfig $serializedConfig


### PR DESCRIPTION
Tests are failing on pwsh 7.4 because it stopped accepting `'System.Collections.ArrayList()'` as an argument to `New-Object`.

Removing the extra parentheses should fix the issue.